### PR TITLE
Clean up headers.

### DIFF
--- a/include/net/kfi/kfi.h
+++ b/include/net/kfi/kfi.h
@@ -33,39 +33,11 @@
 #ifndef _KFI_H_
 #define _KFI_H_
 
-#include <linux/kernel.h>
-#include <linux/module.h>
-#include <linux/byteorder/generic.h>
-#include <linux/slab.h>
-#include <linux/mutex.h>
-#include <linux/string.h>
-
-#include "net/kfi/debug.h"
-
 #define strdup(s) kstrdup(s, GFP_KERNEL)
-
-#include <net/kfi/fabric.h>
-#include <net/kfi/fi_atomic.h>
-
-#ifdef INCLUDE_VALGRIND
-#   include <valgrind/memcheck.h>
-#   ifndef VALGRIND_MAKE_MEM_DEFINED
-#      warning "Valgrind requested, but VALGRIND_MAKE_MEM_DEFINED undefined"
-#   endif
-#endif
-
-#ifndef VALGRIND_MAKE_MEM_DEFINED
-#   define VALGRIND_MAKE_MEM_DEFINED(addr, len)
-#endif
 
 #define ntohll(x) be64_to_cpu(x)
 #define htonll(x) cpu_to_be64(x)
 
 #define sizeof_field(type, field) sizeof(((type *)0)->field)
-
-#define DEFAULT_ABI "FABRIC_1.0"
-
-/* FABRIC_1.0: default symbol set must match linker script */
-#define FABRIC_10(SYM, ESYM) asm(".symver " #SYM","#ESYM"@@FABRIC_1.0");
 
 #endif /* _KFI_H_ */

--- a/include/net/kfi/kfi_internal.h
+++ b/include/net/kfi/kfi_internal.h
@@ -53,6 +53,6 @@ struct kfi_prov {
 	struct kfi_provider	*provider;
 };
 
-extern void fi_freeinfo_internal(struct fi_info *info);
+void fi_freeinfo_internal(struct fi_info *info);
 
 #endif /* _KFI_INTERNAL_H_ */

--- a/include/net/kfi/kfi_provider.h
+++ b/include/net/kfi/kfi_provider.h
@@ -33,17 +33,9 @@
 #ifndef _KFI_PROVIDER_H_
 #define _KFI_PROVIDER_H_
 
-#include <linux/kernel.h>
-#include <linux/byteorder/generic.h>
-#include <linux/semaphore.h>
-#include <linux/list.h>
-#include <linux/string.h>
+#include <net/kfi/fabric.h>
 
 #include <net/kfi/kfi.h>
-
-#ifndef strdup
-#define strdup(s) kstrdup((s), GFP_KERNEL)
-#endif
 
 struct kfi_provider {
 	const char *name;

--- a/kfi/common.c
+++ b/kfi/common.c
@@ -29,6 +29,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include <linux/module.h>
+#include <linux/slab.h>
 
 #include <net/kfi/kfi.h>
 

--- a/kfi/kfi.c
+++ b/kfi/kfi.c
@@ -30,11 +30,18 @@
  * SOFTWARE.
  */
 
+#include <linux/string.h>
+#include <linux/slab.h>
+#include <linux/module.h>
+
+#include <net/kfi/fabric.h>
+#include <net/kfi/fi_errno.h>
+#include <net/kfi/fi_atomic.h>
+
 #include <net/kfi/kfi_internal.h>
 #include <net/kfi/kfi_provider.h>
-#include <linux/string.h>
+#include <net/kfi/debug.h>
 
-#include <net/kfi/fi_errno.h>
 
 int kfi_register_provider(uint32_t version, struct kfi_provider *provider)
 {

--- a/kfi/main.c
+++ b/kfi/main.c
@@ -45,8 +45,11 @@
 #include <linux/sysctl.h>
 #include <linux/proc_fs.h>
 
+#include <net/kfi/fabric.h>
+
 #include "net/kfi/kfi_internal.h"
 #include "net/kfi/kfi_provider.h"
+#include "net/kfi/debug.h"
 
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("Kernel OpenFabrics Interface");


### PR DESCRIPTION
Remove mention of userspace: valgrind, symbol versioning
Remove duplicate define of strdup
fi_freeinfo_internal declaration should not be extern in header
Remove extra includes.

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
