### PR TITLE
Move extern void fi_freeinfo_internal(struct fi_info *info) from kfi_…

### DIFF
--- a/include/net/kfi/kfi_internal.h
+++ b/include/net/kfi/kfi_internal.h
@@ -53,6 +53,4 @@ struct kfi_prov {
 	struct kfi_provider	*provider;
 };
 
-extern void fi_freeinfo_internal(struct fi_info *info);
-
 #endif /* _KFI_INTERNAL_H_ */

--- a/kfi/kfi.c
+++ b/kfi/kfi.c
@@ -36,6 +36,8 @@
 
 #include <net/kfi/fi_errno.h>
 
+void fi_freeinfo_internal(struct fi_info *info);
+
 int kfi_register_provider(uint32_t version, struct kfi_provider *provider)
 {
 	struct kfi_prov *prov;


### PR DESCRIPTION
…internal.h

declaration to where it is used (kfi.c)
