### PR TITLE
Fix compilation of verbs provider with ofed 3.12-1

### DIFF
--- a/README
+++ b/README
@@ -51,15 +51,3 @@ KFI API definition
 1) fi_getinfo() argument 'portnum' is a string in SFI, in KFI it's an integer.
    fi_getinfo() remove node, portnum and flags call argument.
 
-
-KFI using the ibverbs (OFED/InfiniBand) provider
-------------------------------------
-
-1) Out of kernel build Failures due to a bug in OFED-3.12 which is fixed by
-changing /usr/src/compat-rdma/linux/kthread.h to define
-CONFIG_COMPAT_IS_KTHREAD before the '#ifndef CONFIG_COMPAT_IS_KTHREAD' line.
-
-Things to do
-------------
-
-Please see TODO file.

--- a/TODO
+++ b/TODO
@@ -14,3 +14,10 @@
 
 5) Complete the verbs provider such that Infiniband & iWARP devices supported.
 
+6) Fix makefiles. Both the kfi and provider makefiles should be made to properly
+   depend on compat-rdma (when available, if not just use system's kernel/IB stack).
+   I think the compat-rdma kernel modules have in mind some sort of scheme where
+   a dependent module includes config.mk in the Makefile, and then includes one
+   or more of the auto-generated headers to pick the right compat defines.
+   However this does not work. Section 4 of the OFED_tips.txt which talks about
+   this is outdated and/or incorrect. Perhaps a bug needs to be filed.

--- a/prov/verbs/ibvp.h
+++ b/prov/verbs/ibvp.h
@@ -37,7 +37,12 @@
 #ifndef _IBVP_H_
 #define _IBVP_H_
 
+/* hack to work around OFED 3.12-1 duplicate defs */
+#define CONFIG_COMPAT_IS_KTHREAD
+#include <linux/kthread.h>
+
 #include "net/kfi/kfi_provider.h"
+#include "net/kfi/debug.h"
 
 #include <rdma/ib_verbs.h>
 #include <rdma/ib_pack.h>

--- a/prov/verbs/main.c
+++ b/prov/verbs/main.c
@@ -39,7 +39,7 @@
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include <linux/kthread.h>
+
 #include <linux/netdevice.h>
 #include <linux/inetdevice.h>
 #include <linux/net.h>
@@ -50,7 +50,6 @@
 #include <linux/uio.h>
 
 #include <rdma/ib_verbs.h>
-#include <rdma/rdma_cm.h>
 
 #include "ibvp.h"
 

--- a/tests/verbs/mm2/cli/main.c
+++ b/tests/verbs/mm2/cli/main.c
@@ -32,7 +32,6 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include <linux/kthread.h>
 #include <linux/sched.h>
 #include <linux/delay.h>
 #include <linux/time.h>

--- a/tests/verbs/mm2/cli/test.c
+++ b/tests/verbs/mm2/cli/test.c
@@ -32,7 +32,6 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include <linux/kthread.h>
 #include <linux/string.h>
 #include <linux/inet.h>
 #include <linux/sched.h>

--- a/tests/verbs/mm2/common.h
+++ b/tests/verbs/mm2/common.h
@@ -30,8 +30,12 @@
  * SOFTWARE.
  */
 
-#ifndef _TEST_H_
-#define _TEST_H_
+#ifndef _COMMON_H_
+#define _COMMON_H_
+
+/* hack to work around OFED 3.12-1 duplicate defs */
+#define CONFIG_COMPAT_IS_KTHREAD
+#include <linux/kthread.h>
 
 #include <net/kfi/debug.h>
 
@@ -67,4 +71,4 @@ int create_connection(void);
 int do_test(void);
 void destroy_connection(void);
 
-#endif /* _TEST_H_ */
+#endif /* _COMMON_H_ */

--- a/tests/verbs/mm2/svr/main.c
+++ b/tests/verbs/mm2/svr/main.c
@@ -32,7 +32,6 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include <linux/kthread.h>
 #include <linux/sched.h>
 #include <linux/delay.h>
 

--- a/tests/verbs/mm2/svr/test.c
+++ b/tests/verbs/mm2/svr/test.c
@@ -32,7 +32,6 @@
 
 #include <linux/module.h>
 #include <linux/kernel.h>
-#include <linux/kthread.h>
 #include <linux/string.h>
 #include <linux/inet.h>
 #include <linux/delay.h>


### PR DESCRIPTION
This commit works around the multiple definition errors and allows compilation on RHEL 6.6 without
modifying the installed headers as described in the README.

The correct fix for this is to modify the makefiles to properly depend on the compat-rdma kernel
modules/symbols. I can't figure this out however and the only apparent documentation (OFED_tips.txt
section 4) is out of date and wrong.

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
